### PR TITLE
Add Storage Blob Data Contributor role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,12 @@ resource "vault_azure_secret_backend_role" "subscription_owner" {
     scope     = "/subscriptions/${var.image_gallery_subscription_id}"
   }
 
+
+  azure_roles {
+    role_name = "Storage Blob Data Contributor"
+    scope     = "/subscriptions/${var.storage_blob_subscription_id}"
+  }
+
   azure_groups {
     group_name = var.azuread_group_name
   }

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,6 @@ resource "vault_azure_secret_backend_role" "subscription_owner" {
     scope     = "/subscriptions/${var.image_gallery_subscription_id}"
   }
 
-
   azure_roles {
     role_name = "Storage Blob Data Contributor"
     scope     = "/subscriptions/${var.storage_blob_subscription_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "image_gallery_subscription_id" {
 }
 
 variable "storage_blob_subscription_id" {
-  description = "Test role for storage account issue"
+  description = "Azure terraform prod subscription ID to allow access to storage containers and blobs"
   type        = string
-  default     = "b30ec755-1667-45bd-97ba-900e948077d9" # us-terraform-nonprod
+  default     = "debc4966-2669-4fa7-9bd9-c4cdb08aed9f" # us-terraform-prod
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,14 +52,20 @@ variable "azuread_group_name" {
   type        = string
 }
 
-variable "root_management_group" { 
+variable "root_management_group" {
   description = "Root management group to allow network peering"
-  type = string
-  default = "RISK"
+  type        = string
+  default     = "RISK"
 }
 
 variable "image_gallery_subscription_id" {
   description = "Azure Shared Image Gallery Subscription ID"
-  type = string
-  default = "ed5e2254-5d87-4255-b70e-1b5eba509f73" # us-sharedimages-prod
+  type        = string
+  default     = "ed5e2254-5d87-4255-b70e-1b5eba509f73" # us-sharedimages-prod
+}
+
+variable "storage_blob_subscription_id" {
+  description = "Test role for storage account issue"
+  type        = string
+  default     = "b30ec755-1667-45bd-97ba-900e948077d9" # us-terraform-nonprod
 }


### PR DESCRIPTION
Issue: TFE prod workspaces cannot access storage blobs and containers during the terraform plan/apply.

Fix: Temporarily adding Storage Blob Data Contributor role for prod subscription.